### PR TITLE
Updated dependencies to latest for react/jsdom/mocha etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "domino": "^1.0.28",
     "jsdom": "^11.0.0",
     "mocha": "^3.4.2",
-	"react-test-renderer": "^15.6.1",
+    "react-test-renderer": "^15.6.1",
     "unexpected": "^10.29.0",
-	"unexpected-react": "^4.1.0"
+    "unexpected-react": "^4.1.0"
   },
   "dependencies": {
     "react": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -5,19 +5,19 @@
     "test": "mocha --compilers js:babel-core/register src/tests/*.spec.js"
   },
   "devDependencies": {
-    "babel-cli": "^6.1.18",
-    "babel-core": "^6.1.21",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-react": "^6.1.18",
-    "domino": "^1.0.19",
-    "jsdom": "^7.0.2",
-    "mocha": "^2.3.3",
-    "unexpected": "^10.1.0"
+    "babel-cli": "^6.24.1",
+    "babel-core": "^6.25.0",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "domino": "^1.0.28",
+    "jsdom": "^11.0.0",
+    "mocha": "^3.4.2",
+	"react-test-renderer": "^15.6.1",
+    "unexpected": "^10.29.0",
+	"unexpected-react": "^4.1.0"
   },
   "dependencies": {
-    "react": "^0.14.2",
-    "react-addons-test-utils": "^0.14.2",
-    "react-dom": "^0.14.2",
-    "unexpected-react": "^0.3.0"
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1"
   }
 }

--- a/src/testHelpers/emulateDom.js
+++ b/src/testHelpers/emulateDom.js
@@ -1,12 +1,19 @@
 if (typeof document === 'undefined') {
+    const { JSDOM } = require('jsdom');
+    const jsdom = new JSDOM('<!doctype html><html><body></body></html>');
+    const { window } = jsdom;
 
-    const jsdom = require('jsdom').jsdom;
-    global.document = jsdom('');
-    global.window = global.document.defaultView;
-
-    for (let key in global.window) {
-        if (!global[key]) {
-            global[key] = global.window[key];
-        }
+    function copyProps(src, target) {
+        const props = Object.getOwnPropertyNames(src)
+            .filter(prop => typeof target[prop] === 'undefined')
+            .map(prop => Object.getOwnPropertyDescriptor(src, prop));
+        Object.defineProperties(target, props);
     }
+
+    global.window = window;
+    global.document = window.document;
+    global.navigator = {
+        userAgent: 'node.js'
+    };
+    copyProps(window, global);
 }

--- a/src/tests/Select.spec.js
+++ b/src/tests/Select.spec.js
@@ -5,7 +5,7 @@ const UnexpectedReact = require('unexpected-react');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-dom/test-utils');
 
 const Select = require('../Select');
 const SelectOption = require('../SelectOption');

--- a/src/tests/SelectOption.spec.js
+++ b/src/tests/SelectOption.spec.js
@@ -6,7 +6,7 @@ const Unexpected = require('unexpected');
 const UnexpectedReact = require('unexpected-react');
 
 var React = require('react');
-var TestUtils = require('react-addons-test-utils');
+var TestUtils = require('react-test-renderer/shallow');
 
 const SelectOption = require('../SelectOption');
 


### PR DESCRIPTION
Please, update example. 
Motivation:
- react-addons-test-utils were deprecated (see https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html)
- there are changes to jsdom API (see https://changelogs.md/github/tmpvar/jsdom/)